### PR TITLE
  - Add default attribute for the Spacewalk Server's SSL cert

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['segulja_spacewalk']['spacewalk_org_trusted_ssl_cert'] = 'http://spacewalk.segulja.com/pub/RHN-ORG-TRUSTED-SSL-CERT'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,3 +4,23 @@
 #
 # Copyright:: 2018, The Authors, All Rights Reserved.
 
+remote_file '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT' do
+  source node['segulja_spacewalk']['spacewalk_org_trusted_ssl_cert']
+  action :create
+end
+
+execute 'Register with the Spacewalk Server' do
+  command <<-EOC
+    rhnreg_ks --sslCACert=/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT \\
+        --serverUrl=http://spacewalk.segulja.com/XMLRPC \\
+        --activationkey=1-oraclelinux7-x86_64
+    EOC
+  action :run
+  not_if { ::File.exist?('/etc/sysconfig/rhn/systemid') }
+end
+
+%w(rhn-client-tools rhn-check rhn-setup rhnsd m2crypto yum-rhn-plugin osad).each do |pkg|
+  package pkg do
+    action :install
+  end
+end


### PR DESCRIPTION
  - Use remote file resource to copy the SSL cert from the Spacewalk Server to the node
  - Version 0.1.0

On branch register-to-spacewalk
Your branch is up to date with 'origin/register-to-spacewalk'.

Changes to be committed:
modified:   attributes/default.rb
modified:   recipes/default.rb